### PR TITLE
Fix number of eq steps for OpenMM

### DIFF
--- a/pyMDMix/QueueWriting.py
+++ b/pyMDMix/QueueWriting.py
@@ -135,7 +135,7 @@ class QueueInputWriter(object):
         # EQUILIBRATION
         jobname = replica.name+'_eq'
         precommands = ''
-        if replica.mdProgram == ('AMBER' or 'OPENMM'): neqsteps = 5
+        if replica.mdProgram in {'AMBER', 'OPENMM'}: neqsteps = 5
         else: neqsteps = 2
         commands = '\n'.join([writer.getCommand('eq',i) for i in range(1,neqsteps+1)])
         postcommands = 'cd ..'+os.sep+replica.mdfolder


### PR DESCRIPTION
It seems the previous commit c08480b2a06aa59a13540727fb1a3de956efe659 didn't quite get this right - OpenMM still falls back to the default of 2 eq steps. This should ensure 5 steps.